### PR TITLE
Updated Build Pipeline and repo link

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,42 @@
+on: [push, pull_request]
+name: Build and Publish to NPM
+jobs:
+    test:
+        name: Build
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Use Node.js 12
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 12
+            - name: Cache node_modules
+              id: cache-modules
+              uses: actions/cache@v1
+              with:
+                  path: node_modules
+                  key: 12.x-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
+            - name: Build
+              if: steps.cache-modules.outputs.cache-hit != 'true'
+              run: npm install
+    publish:
+        name: Publish
+        needs: test
+        runs-on: ubuntu-latest
+        if: github.event_name == 'push' && ( github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' )
+        steps:
+            - uses: actions/checkout@v2
+            - name: Cache node_modules
+              id: cache-modules
+              uses: actions/cache@v1
+              with:
+                  path: node_modules
+                  key: 12.x-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
+            - name: Build
+              if: steps.cache-modules.outputs.cache-hit != 'true'
+              run: npm install
+            - name: Publish
+              uses: mikeal/merge-release@master
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
 	"name": "drpg-utils",
 	"description": "Common functions used by the DRPG Suite",
-	"version": "1.2.1",
+	"version": "0.0.0-dev",
 	"author": "Bejasc",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/drpgdev/drpg-utils"
+		"url": "https://github.com/bejasc/drpg-utils"
 	},	
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
npm-publish workflow now uses [merge-release](https://github.com/mikeal/merge-release) by mikeal.

Instead, the build process will automatically handle versioning.

Refer to the doc above for how and when versions are incremented (based on keywords in the commit)